### PR TITLE
Ensure consistent shebangs

### DIFF
--- a/build-toolchain.sh
+++ b/build-toolchain.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 export PREFIX="$HOME/opt/cross"
 export TARGET=i686-elf
 export PATH="$PREFIX/bin:$PATH"

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 export PREFIX="$HOME/opt/cross"
 export TARGET=i686-elf
 export PATH="$PREFIX/bin:$PATH"

--- a/x64/build.sh
+++ b/x64/build.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 rm -rf ./build/os.bin
 
 nasm -f bin -o ./build/boot.bin ./src/boot.asm

--- a/x64/build2.sh
+++ b/x64/build2.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 nasm -f bin -o boot.bin ./src/boot.asm
 nasm -f bin -o loader.bin ./src/loader.asm
 dd if=boot.bin of=boot.img bs=512 count=1 conv=notrunc


### PR DESCRIPTION
## Summary
- fix the first line of build scripts to properly use `#!/bin/bash`
- add missing shebangs to x64 scripts

## Testing
- `git log -1 --stat`