### PR TITLE
Fix tss field name

### DIFF
--- a/src/proc/tss.h
+++ b/src/proc/tss.h
@@ -10,7 +10,7 @@ struct tss
     uint32_t esp1;
     uint32_t esp2;
     uint32_t ss2;
-    uint32_t sr3;
+    uint32_t cr3;  /* Page directory base register */
     uint32_t eip;
     uint32_t eflags;
     uint32_t eax;


### PR DESCRIPTION
## Summary
- rename the `sr3` field in the TSS structure to `cr3`
- document that it stores the page directory base register

## Testing
- `make` *(fails: unable to open output file)*