### PR TITLE
Start 64-bit toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-C_COMPILER = i686-elf-gcc
+C_COMPILER = x86_64-elf-gcc
+LD = x86_64-elf-ld
 FILES = ./build/kernel.asm.o ./build/idt.asm.o ./build/io.asm.o ./build/task.asm.o ./build/tss.asm.o ./build/gdt.asm.o ./build/paging.asm.o ./build/kernel.o ./build/idt.o ./build/stdlib.o ./build/stdio.o ./build/string.o ./build/heap.o ./build/kheap.o ./build/paging.o ./build/disk.o ./build/pparser.o ./build/streamer.o ./build/file.o ./build/fat16.o ./build/gdt.o ./build/task.o ./build/process.o ./build/isr80h.o ./build/commands.o ./build/keyboard.o ./build/classic.o ./build/math.o
 INCLUDES = -I./src
 FLAGS = -g -ffreestanding -falign-jumps -falign-functions -falign-labels -falign-loops -fstrength-reduce -fomit-frame-pointer -finline-functions -Wno-unused-function -fno-builtin -Werror -Wno-unused-label -Wno-cpp -Wno-unused-parameter -nostdlib -nostartfiles -nodefaultlibs -Wall -O0 -Iinc
@@ -17,95 +18,95 @@ all: ./bin/boot.bin ./bin/kernel.bin user_programs
 	cp ./bin/os.bin ./images/dexter.img
 
 ./bin/kernel.bin: $(FILES)
-	i686-elf-ld -g -relocatable $(FILES) -o ./build/kernelfull.o
-	i686-elf-gcc $(FLAGS) -T ./linker.ld -o ./bin/kernel.bin -ffreestanding -O0 -nostdlib ./build/kernelfull.o
+	$(LD) -g -relocatable $(FILES) -o ./build/kernelfull.o
+	$(C_COMPILER) $(FLAGS) -T ./linker64.ld -o ./bin/kernel.bin -ffreestanding -O0 -nostdlib ./build/kernelfull.o
 
 ./bin/boot.bin: ./src/x86/boot.asm
 	nasm -f bin ./src/x86/boot.asm -o ./bin/boot.bin
 
-./build/kernel.asm.o: ./src/x86/kernel.asm
-	nasm -f elf -g ./src/x86/kernel.asm -o ./build/kernel.asm.o
+./build/kernel.asm.o: ./src/x64/kernel.asm
+	nasm -f elf64 -g ./src/x64/kernel.asm -o ./build/kernel.asm.o
 
 ./build/gdt.asm.o: ./src/x86/gdt.asm
-	nasm -f elf -g ./src/x86/gdt.asm -o ./build/gdt.asm.o
+	nasm -f elf64 -g ./src/x86/gdt.asm -o ./build/gdt.asm.o
 
 ./build/idt.asm.o: ./src/x86/idt.asm
-	nasm -f elf -g ./src/x86/idt.asm -o ./build/idt.asm.o
+	nasm -f elf64 -g ./src/x86/idt.asm -o ./build/idt.asm.o
 
 ./build/io.asm.o: ./src/x86/io.asm
-	nasm -f elf -g ./src/x86/io.asm -o ./build/io.asm.o
+	nasm -f elf64 -g ./src/x86/io.asm -o ./build/io.asm.o
 
 ./build/task.asm.o: ./src/x86/task.asm
-	nasm -f elf -g ./src/x86/task.asm -o ./build/task.asm.o
+	nasm -f elf64 -g ./src/x86/task.asm -o ./build/task.asm.o
 
 ./build/tss.asm.o: ./src/x86/tss.asm
-	nasm -f elf -g ./src/x86/tss.asm -o ./build/tss.asm.o
+	nasm -f elf64 -g ./src/x86/tss.asm -o ./build/tss.asm.o
 
 ./build/paging.asm.o: ./src/x86/paging.asm
-	nasm -f elf -g ./src/x86/paging.asm -o ./build/paging.asm.o
+	nasm -f elf64 -g ./src/x86/paging.asm -o ./build/paging.asm.o
 
 ./build/kernel.o: ./src/sys/kernel.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/sys/kernel.c -o ./build/kernel.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/sys/kernel.c -o ./build/kernel.o
 	
 ./build/gdt.o: ./src/sys/gdt.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/sys/gdt.c -o ./build/gdt.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/sys/gdt.c -o ./build/gdt.o
 
 ./build/keyboard.o: ./src/dev/keyboard.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/dev/keyboard.c -o ./build/keyboard.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/dev/keyboard.c -o ./build/keyboard.o
 
 ./build/classic.o: ./src/dev/classic.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/dev/classic.c -o ./build/classic.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/dev/classic.c -o ./build/classic.o
 
 ./build/fat16.o: ./src/fs/fat16.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/fs/fat16.c -o ./build/fat16.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/fs/fat16.c -o ./build/fat16.o
 
 ./build/file.o: ./src/fs/file.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/fs/file.c -o ./build/file.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/fs/file.c -o ./build/file.o
 
 ./build/streamer.o: ./src/fs/streamer.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/fs/streamer.c -o ./build/streamer.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/fs/streamer.c -o ./build/streamer.o
 
 ./build/pparser.o: ./src/fs/pparser.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/fs/pparser.c -o ./build/pparser.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/fs/pparser.c -o ./build/pparser.o
 
 ./build/disk.o: ./src/fs/disk.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/fs/disk.c -o ./build/disk.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/fs/disk.c -o ./build/disk.o
 
 ./build/idt.o: ./src/sys/idt.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/sys/idt.c -o ./build/idt.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/sys/idt.c -o ./build/idt.o
 
 ./build/paging.o: ./src/mem/paging.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/mem/paging.c -o ./build/paging.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/mem/paging.c -o ./build/paging.o
 
 ./build/kheap.o: ./src/mem/kheap.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/mem/kheap.c -o ./build/kheap.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/mem/kheap.c -o ./build/kheap.o
 
 ./build/heap.o: ./src/mem/heap.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/mem/heap.c -o ./build/heap.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/mem/heap.c -o ./build/heap.o
 
 ./build/task.o: ./src/proc/task.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/proc/task.c -o ./build/task.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/proc/task.c -o ./build/task.o
 
 ./build/process.o: ./src/proc/process.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/proc/process.c -o ./build/process.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/proc/process.c -o ./build/process.o
 
 ./build/isr80h.o: ./src/proc/isr80h.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/proc/isr80h.c -o ./build/isr80h.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/proc/isr80h.c -o ./build/isr80h.o
 
 ./build/commands.o: ./src/proc/commands.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/proc/commands.c -o ./build/commands.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/proc/commands.c -o ./build/commands.o
 
 ./build/math.o: ./src/libc/math.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/libc/math.c -o ./build/math.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/libc/math.c -o ./build/math.o
 
 ./build/string.o: ./src/libc/string.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/libc/string.c -o ./build/string.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/libc/string.c -o ./build/string.o
 
 ./build/stdio.o: ./src/libc/stdio.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/libc/stdio.c -o ./build/stdio.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/libc/stdio.c -o ./build/stdio.o
 
 ./build/stdlib.o: ./src/libc/stdlib.c
-	i686-elf-gcc $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/libc/stdlib.c -o ./build/stdlib.o
+	$(C_COMPILER) $(INCLUDES) $(FLAGS) -std=gnu99 -c ./src/libc/stdlib.c -o ./build/stdlib.o
 
 user_programs:
 	cd ./progs/blank && $(MAKE) all
@@ -114,7 +115,7 @@ user_programs_clean:
 	cd ./progs/blank && $(MAKE) clean
 
 run:
-	qemu-system-i386 -hda ./images/dexter.img
+	qemu-system-x86_64 -hda ./images/dexter.img
 
 clean: user_programs_clean
 	rm -rf ./bin

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-export PREFIX="$HOME/opt/cross"
-export TARGET=i686-elf
+export PREFIX="$HOME/opt/cross64"
+export TARGET=x86_64-elf
 export PATH="$PREFIX/bin:$PATH"
 mkdir -p ./build ./bin
 make all

--- a/doc/gdb_cmds.txt
+++ b/doc/gdb_cmds.txt
@@ -1,5 +1,5 @@
 add-symbol-file ./build/kernelfull.o 0x100000
-target remote | qemu-system-i386 -hda ./bin/os.bin -gdb stdio -S
+target remote | qemu-system-x86_64 -hda ./bin/os.bin -gdb stdio -S
 break kernel_main
 
 c = continue

--- a/linker64.ld
+++ b/linker64.ld
@@ -1,0 +1,14 @@
+ENTRY(_start)
+OUTPUT_FORMAT(elf64-x86-64)
+SECTIONS
+{
+    . = 1M;
+    .text : ALIGN(4096) { *(.text) }
+    .rodata : ALIGN(4096) { *(.rodata) }
+    .data : ALIGN(4096) { *(.data) }
+    .bss : ALIGN(4096)
+    {
+        *(COMMON)
+        *(.bss)
+    }
+}

--- a/progs/blank/Makefile
+++ b/progs/blank/Makefile
@@ -1,7 +1,7 @@
 all:
-	mkdir ./build
-	nasm -f elf ./blank.asm -o ./build/blank.o
-	i686-elf-gcc -g -T ./linker.ld -o blank.bin -ffreestanding -O0 -nostdlib -fpic -g ./build/blank.o
+    mkdir ./build
+    nasm -f elf64 ./blank.asm -o ./build/blank.o
+    x86_64-elf-gcc -g -T ../../linker64.ld -o blank.bin -ffreestanding -O0 -nostdlib -fpic -g ./build/blank.o
 
 clean:
 	rm -rf ./build/

--- a/src/x64/kernel.asm
+++ b/src/x64/kernel.asm
@@ -1,0 +1,11 @@
+[BITS 64]
+
+global _start
+extern kernel_main
+
+_start:
+    mov rsp, 0x00200000
+    call kernel_main
+.hang:
+    hlt
+    jmp .hang


### PR DESCRIPTION
## Summary
- switch build scripts to use a 64-bit cross toolchain
- add a 64-bit linker script
- compile assembly and C code with x86_64 tools
- provide a very small 64-bit kernel entry stub
- update run instructions and program Makefiles for x86-64

## Testing
- `./build.sh` *(fails: instruction not supported in 64-bit mode)*

------
https://chatgpt.com/codex/tasks/task_e_683cb2deeb8c832498973c51f624bbd6